### PR TITLE
QPPSF-2761 Remove Performance at the Measurement Level

### DIFF
--- a/src/com/eviware/soapui/ScenarioReader.groovy
+++ b/src/com/eviware/soapui/ScenarioReader.groovy
@@ -155,7 +155,6 @@ class ScenarioReader {
     def measureList = [];
     list.each { s ->
       def measureCategory = s.data.get('category')
-      def perfYear = s.data.get('perf_year')
       if (s.data.get('mset_id') != msetConstraint) { return; }
       // Begin ACI Measurement Creation
       if (measureCategory == 'aci' || measureCategory == 'pi') {
@@ -189,7 +188,7 @@ class ScenarioReader {
             s.data.put('IDX_READD_PAIR_COUNTS', acrList.join(','))
             s.data.put('idxAdminCodes', indexAdmissionCodes.join(','))
             s.data.put('readdCodes', readmissionCodes.join(','))
-            measureList << SNIPPETS['ACR_MEASURE'])
+            measureList << s.eval(SNIPPETS['ACR_MEASURE'])
           } else {
             // Stratum Measures
             def stratumList = [];
@@ -200,25 +199,25 @@ class ScenarioReader {
             s.data.put('STRATUM', stratumList.join(','))
             // Proportional Stratum Measures
             if (!this.isEmptyOrNull(s.data.get('performanceRate'))) {
-              measureList << SNIPPETS['PROP_MULTI_MEASURE_TPL'])
+              measureList << s.eval(SNIPPETS['PROP_MULTI_MEASURE_TPL'])
             // Stratum Measures
             } else {
-              measureList << SNIPPETS['MULTI_MEASURE'])
+              measureList << s.eval(SNIPPETS['MULTI_MEASURE'])
             }
           }
         } else {
           // CAHPS Measure
           if (!this.isEmptyOrNull(s.data.get('cahps_reliability')) && !this.isEmptyOrNull(s.data.get('cahps_mask')) && !this.isEmptyOrNull(s.data.get('cahps_isBelowMinimum'))) {
-            measureList << SNIPPETS['CAHPS_MEASURE_TPL'])
+            measureList << s.eval(SNIPPETS['CAHPS_MEASURE_TPL'])
           // NonProportional Measure
           } else if (!this.isEmptyOrNull(s.data.get('end_to_end')) && !this.isEmptyOrNull(s.data.get('numerator')) && !this.isEmptyOrNull(s.data.get('denominator')) && !this.isEmptyOrNull(s.data.get('denominator_exc')) && !this.isEmptyOrNull(s.data.get('numerator_exc'))) {
-            measureList << SNIPPETS['NONPROP_MEASURE_TPL'])
+            measureList << s.eval(SNIPPETS['NONPROP_MEASURE_TPL'])
           // Proportional Measure
           } else if (!this.isEmptyOrNull(s.data.get('performanceRate'))) {
-            measureList << SNIPPETS['PROP_MEASURE_TPL'])
+            measureList << s.eval(SNIPPETS['PROP_MEASURE_TPL'])
           // Standard Single Measure
           } else {
-            measureList << SNIPPETS['SINGLE_MEASURE'])
+            measureList << s.eval(SNIPPETS['SINGLE_MEASURE'])
           }
         }
       } else if (measureCategory == 'cost') {
@@ -235,8 +234,6 @@ class ScenarioReader {
   public String toMeasurementSets(List<Scenario> list) {
     def Set msetList = [];
     list.each { s ->
-      def measureCategory = s.data.get('category')
-      def perfYear = s.data.get('perf_year')
       def msetName = s.data.get('mset_id')
       s.data.put('MEASUREMENTS', '${MEASUREMENTS_' + msetName + '}' )
       msetList << s.eval(SNIPPETS['MSET_TEMPLATE'])

--- a/src/com/eviware/soapui/ScenarioReader.groovy
+++ b/src/com/eviware/soapui/ScenarioReader.groovy
@@ -58,7 +58,7 @@ class ScenarioReader {
     this.addXSnippet('COST_MEASURE_TEMPLATE', '{"measureId":"${measure_id}","value":{"score":${score},"details":{"ratio":${ratio},"eligibleOccurrences":${eligibleOccurrences},"costPerOccurrence":${costPerOccurrence}}}}')
   }
 
-// ScenarioReader -- Class used to initialize all necessary files 
+// ScenarioReader -- Class used to initialize all necessary files
   public ScenarioReader(String folder, String inputFileName, String outputFileName) {
     this.cfgSnippets()
     this.inputFile = new File(folder, inputFileName);
@@ -108,7 +108,7 @@ class ScenarioReader {
 /* addXSnippet -- A function for creating snippets or templates. Primarily used to set templates for measurements or basic JSON structures for API calls.
 ** -- Note --
 ** In the newSnippet string, values wrapped in ${} are replaced by the corresponding PROP name either defined in code or the column name in the TSV.
-** 
+**
 ** @param name       :: String -- ex. "MEASUREMENT_TEMPLATE"
 ** @param newSnippet :: String -- ex. '{ "name": ${MEASURE_NAME}, "value": ${MEASURE_VALUE}}'
 */
@@ -155,6 +155,7 @@ class ScenarioReader {
     def measureList = [];
     list.each { s ->
       def measureCategory = s.data.get('category')
+      def perfYear = s.data.get('perf_year')
       if (s.data.get('mset_id') != msetConstraint) { return; }
       // Begin ACI Measurement Creation
       if (measureCategory == 'aci' || measureCategory == 'pi') {
@@ -188,7 +189,7 @@ class ScenarioReader {
             s.data.put('IDX_READD_PAIR_COUNTS', acrList.join(','))
             s.data.put('idxAdminCodes', indexAdmissionCodes.join(','))
             s.data.put('readdCodes', readmissionCodes.join(','))
-            measureList << s.eval(SNIPPETS['ACR_MEASURE'])
+            measureList << SNIPPETS['ACR_MEASURE'])
           } else {
             // Stratum Measures
             def stratumList = [];
@@ -199,25 +200,25 @@ class ScenarioReader {
             s.data.put('STRATUM', stratumList.join(','))
             // Proportional Stratum Measures
             if (!this.isEmptyOrNull(s.data.get('performanceRate'))) {
-              measureList << s.eval(SNIPPETS['PROP_MULTI_MEASURE_TPL'])
+              measureList << SNIPPETS['PROP_MULTI_MEASURE_TPL'])
             // Stratum Measures
             } else {
-              measureList << s.eval(SNIPPETS['MULTI_MEASURE'])
+              measureList << SNIPPETS['MULTI_MEASURE'])
             }
           }
         } else {
           // CAHPS Measure
           if (!this.isEmptyOrNull(s.data.get('cahps_reliability')) && !this.isEmptyOrNull(s.data.get('cahps_mask')) && !this.isEmptyOrNull(s.data.get('cahps_isBelowMinimum'))) {
-            measureList << s.eval(SNIPPETS['CAHPS_MEASURE_TPL'])
+            measureList << SNIPPETS['CAHPS_MEASURE_TPL'])
           // NonProportional Measure
           } else if (!this.isEmptyOrNull(s.data.get('end_to_end')) && !this.isEmptyOrNull(s.data.get('numerator')) && !this.isEmptyOrNull(s.data.get('denominator')) && !this.isEmptyOrNull(s.data.get('denominator_exc')) && !this.isEmptyOrNull(s.data.get('numerator_exc'))) {
-            measureList << s.eval(SNIPPETS['NONPROP_MEASURE_TPL'])
+            measureList << SNIPPETS['NONPROP_MEASURE_TPL'])
           // Proportional Measure
           } else if (!this.isEmptyOrNull(s.data.get('performanceRate'))) {
-            measureList << s.eval(SNIPPETS['PROP_MEASURE_TPL'])
+            measureList << SNIPPETS['PROP_MEASURE_TPL'])
           // Standard Single Measure
           } else {
-            measureList << s.eval(SNIPPETS['SINGLE_MEASURE'])
+            measureList << SNIPPETS['SINGLE_MEASURE'])
           }
         }
       } else if (measureCategory == 'cost') {
@@ -234,6 +235,8 @@ class ScenarioReader {
   public String toMeasurementSets(List<Scenario> list) {
     def Set msetList = [];
     list.each { s ->
+      def measureCategory = s.data.get('category')
+      def perfYear = s.data.get('perf_year')
       def msetName = s.data.get('mset_id')
       s.data.put('MEASUREMENTS', '${MEASUREMENTS_' + msetName + '}' )
       msetList << s.eval(SNIPPETS['MSET_TEMPLATE'])
@@ -278,4 +281,3 @@ class ScenarioReader {
     copyScenarioProperties(this.propsStep, this.currentScenarioList)
   }
 }
-


### PR DESCRIPTION
Remove Performance at the Measurement Level

---

### Summary

Need to remove measure level performance from SoapUI - ScenarioReader to meet new requirements for https://jira.cms.gov/browse/QPPSF-2691 and https://jira.cms.gov/browse/QPPSF-2692 from a TSV file for SoapUI.

### Test Plan

Things that have to pass. These are things that the reviewer(s) should be able to reproduce.

### Associated JIRA Tickets

https://jira.cms.gov/browse/QPPSF-2761

### Reviewers

@rockykitamura @KyleApfel @bijujoseph 