### PR TITLE
QPPSF-3449 Endpoint Switcher

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 cd ./src/com/eviware/soapui && \
 # Compiling Groovy Files
-groovyc *.groovy && \
+groovyc -cp /Applications/SoapUI-5.4.0.app/Contents/java/app/bin/soapui-5.4.0.jar:/Applications/SoapUI-5.4.0.app/Contents/java/app/lib/log4j-1.2.14.jar *.groovy && \
 mkdir ./src/ && \
 mv ./com/ ./src/ && \
 # Moving Java and their class files to be packaged

--- a/src/com/eviware/soapui/ScenarioReader.groovy
+++ b/src/com/eviware/soapui/ScenarioReader.groovy
@@ -1,4 +1,4 @@
-package com.eviware.soapui
+package com.eviware.soapui;
 
 /* ScenarioReader
 ** :: Notes ::
@@ -41,14 +41,10 @@ class ScenarioReader {
 
 // cfgSnippets -- A function for configuring all measurement templates to later be used in toMeasurementSets() and toMeasurements()
   public void cfgSnippets() {
-    this.addXSnippet('MSET_TEMPLATE', ' {"programName": "mips","category":"${category}","performanceStart":"${perf_start}","performanceEnd":"${perf_end}","submissionMethod": "${sub_method}","measurements":[${MEASUREMENTS}]}')
-    this.addXSnippet('2018_QUALITY_MSET_TEMPLATE', ' {"programName": "mips","category":"${category}","submissionMethod": "${sub_method}","measurements":[${MEASUREMENTS}]}')
+    this.addXSnippet('MSET_TEMPLATE', ' {"programName": "mips","providerId":"${provider_id}","category":"${category}","performanceStart":"${perf_start}","performanceEnd":"${perf_end}","submissionMethod": "${sub_method}","measurements":[${MEASUREMENTS}]}')
     this.addXSnippet('NONPROP_MEASURE_TPL', '{"measureId": "${measure_id}","value": {"isEndToEndReported": ${end_to_end},"numerator": ${numerator},"denominator": ${denominator},"denominatorException": ${denominator_exc},"numeratorExclusion":${numerator_exc}}}')
-    this.addXSnippet('2018_NONPROP_MEASURE_TPL', '{"measureId": "${measure_id}","performanceStart":"${perf_start}","performanceEnd":"${perf_end}","value": {"isEndToEndReported": ${end_to_end},"numerator": ${numerator},"denominator": ${denominator},"denominatorException": ${denominator_exc},"numeratorExclusion":${numerator_exc}}}')
     this.addXSnippet('SINGLE_MEASURE', '{"measureId":"${measure_id}","value":{"isEndToEndReported":${end_to_end},"performanceMet":${perf_met},"eligiblePopulationException":${perf_excep},"eligiblePopulationExclusion":${perf_exclu},"performanceNotMet":${perf_not_met},"eligiblePopulation":${pop_total}}}')
-    this.addXSnippet('2018_SINGLE_MEASURE', '{"measureId":"${measure_id}","performanceStart":"${perf_start}","performanceEnd":"${perf_end}", "value":{"isEndToEndReported":${end_to_end},"performanceMet":${perf_met},"eligiblePopulationException":${perf_excep},"eligiblePopulationExclusion":${perf_exclu},"performanceNotMet":${perf_not_met},"eligiblePopulation":${pop_total}}}')
     this.addXSnippet('MULTI_MEASURE', '{"measureId":"${measure_id}","value":{"isEndToEndReported":${end_to_end},"strata":[${STRATUM}]}}')
-    this.addXSnippet('2018_MULTI_MEASURE', '{"measureId":"${measure_id}","performanceStart":"${perf_start}","performanceEnd":"${perf_end}","value":{"isEndToEndReported":${end_to_end},"strata":[${STRATUM}]}}')
     this.addXSnippet('STRATUM', '{"performanceMet":${perf_met},"eligiblePopulationException":${perf_excep},"eligiblePopulationExclusion":${perf_exclu},"performanceNotMet":${perf_not_met},"eligiblePopulation":${pop_total},"stratum":"${stratum}"}')
     this.addXSnippet('ACI_MEASURE_TEMPLATE', '{"measureId":"${measure_id}","value":${value}}')
     this.addXSnippet('ACI_ALT_MEASURE_TEMPLATE', '{"measureId":"${measure_id}","value":{"numerator":${value_numerator},"denominator":${value_denominator}}}')
@@ -56,13 +52,9 @@ class ScenarioReader {
     this.addXSnippet('ACR_Idx_COUNTS', '{"code":"${indexAdmissionCode}","count":${count}}')
     this.addXSnippet('ACR_Readd_COUNTS', '{"code":"${readmissionCode}","count":${count}}')
     this.addXSnippet('ACR_MEASURE', '{"measureId":"${measure_id}","value":{"score":${score},"details":{"numberOfIndexAdmissions":${numberOfIndexAdmissions},"numberOfReadmissions":${numberOfReadmissions},"indexReadmissionDiagnosisPairCounts":[${IDX_READD_PAIR_COUNTS}],"indexAdmissionCountByDiagnosis":[${idxAdminCodes}],"readmissionCountByDiagnosis":[${readdCodes}],"plannedReadmissions":${plannedReadmissions}}}}')
-    this.addXSnippet('2018_ACR_MEASURE', '{"measureId":"${measure_id}","performanceStart":"${perf_start}","performanceEnd":"${perf_end}","value":{"score":${score},"details":{"numberOfIndexAdmissions":${numberOfIndexAdmissions},"numberOfReadmissions":${numberOfReadmissions},"indexReadmissionDiagnosisPairCounts":[${IDX_READD_PAIR_COUNTS}],"indexAdmissionCountByDiagnosis":[${idxAdminCodes}],"readmissionCountByDiagnosis":[${readdCodes}],"plannedReadmissions":${plannedReadmissions}}}}')
     this.addXSnippet('CAHPS_MEASURE_TPL', '{"measureId":"${measure_id}","value":{"score":${score},"reliability":"${cahps_reliability}","mask":${cahps_mask},"isBelowMinimum":${cahps_isBelowMinimum}}}')
-    this.addXSnippet('2018_CAHPS_MEASURE_TPL', '{"measureId":"${measure_id}","performanceStart":"${perf_start}","performanceEnd":"${perf_end}","value":{"score":${score},"reliability":"${cahps_reliability}","mask":${cahps_mask},"isBelowMinimum":${cahps_isBelowMinimum}}}')
     this.addXSnippet('PROP_MEASURE_TPL', '{"measureId":"${measure_id}","value":{"isEndToEndReported":${end_to_end},"performanceMet":${perf_met},"eligiblePopulationException":${perf_excep},"eligiblePopulationExclusion":${perf_exclu},"performanceNotMet":${perf_not_met},"performanceRate":${performanceRate},"eligiblePopulation":${pop_total}}}')
-    this.addXSnippet('2018_PROP_MEASURE_TPL', '{"measureId":"${measure_id}","performanceStart":"${perf_start}","performanceEnd":"${perf_end}","value":{"isEndToEndReported":${end_to_end},"performanceMet":${perf_met},"eligiblePopulationException":${perf_excep},"eligiblePopulationExclusion":${perf_exclu},"performanceNotMet":${perf_not_met},"performanceRate":${performanceRate},"eligiblePopulation":${pop_total}}}')
     this.addXSnippet('PROP_MULTI_MEASURE_TPL', '{"measureId":"${measure_id}","value":{"isEndToEndReported":${end_to_end},"performanceRate":${performanceRate},"strata":[${STRATUM}]}}')
-    this.addXSnippet('2018_PROP_MULTI_MEASURE_TPL', '{"measureId":"${measure_id}","performanceStart":"${perf_start}","performanceEnd":"${perf_end}","value":{"isEndToEndReported":${end_to_end},"performanceRate":${performanceRate},"strata":[${STRATUM}]}}')
     this.addXSnippet('COST_MEASURE_TEMPLATE', '{"measureId":"${measure_id}","value":{"score":${score},"details":{"ratio":${ratio},"eligibleOccurrences":${eligibleOccurrences},"costPerOccurrence":${costPerOccurrence}}}}')
   }
 
@@ -163,7 +155,6 @@ class ScenarioReader {
     def measureList = [];
     list.each { s ->
       def measureCategory = s.data.get('category')
-      def perfYear = s.data.get('perf_year')
       if (s.data.get('mset_id') != msetConstraint) { return; }
       // Begin ACI Measurement Creation
       if (measureCategory == 'aci' || measureCategory == 'pi') {
@@ -197,7 +188,7 @@ class ScenarioReader {
             s.data.put('IDX_READD_PAIR_COUNTS', acrList.join(','))
             s.data.put('idxAdminCodes', indexAdmissionCodes.join(','))
             s.data.put('readdCodes', readmissionCodes.join(','))
-            measureList << s.eval((perfYear == '2018') ? SNIPPETS['2018_ACR_MEASURE'] : SNIPPETS['ACR_MEASURE'])
+            measureList << s.eval(SNIPPETS['ACR_MEASURE'])
           } else {
             // Stratum Measures
             def stratumList = [];
@@ -208,25 +199,25 @@ class ScenarioReader {
             s.data.put('STRATUM', stratumList.join(','))
             // Proportional Stratum Measures
             if (!this.isEmptyOrNull(s.data.get('performanceRate'))) {
-              measureList << s.eval((perfYear == '2018') ? SNIPPETS['2018_PROP_MULTI_MEASURE_TPL'] : SNIPPETS['PROP_MULTI_MEASURE_TPL'])
+              measureList << s.eval(SNIPPETS['PROP_MULTI_MEASURE_TPL'])
             // Stratum Measures
             } else {
-              measureList << s.eval((perfYear == '2018') ? SNIPPETS['2018_MULTI_MEASURE'] : SNIPPETS['MULTI_MEASURE'])
+              measureList << s.eval(SNIPPETS['MULTI_MEASURE'])
             }
           }
         } else {
           // CAHPS Measure
           if (!this.isEmptyOrNull(s.data.get('cahps_reliability')) && !this.isEmptyOrNull(s.data.get('cahps_mask')) && !this.isEmptyOrNull(s.data.get('cahps_isBelowMinimum'))) {
-            measureList << s.eval((perfYear == '2018') ? SNIPPETS['2018_CAHPS_MEASURE_TPL'] : SNIPPETS['CAHPS_MEASURE_TPL'])
+            measureList << s.eval(SNIPPETS['CAHPS_MEASURE_TPL'])
           // NonProportional Measure
           } else if (!this.isEmptyOrNull(s.data.get('end_to_end')) && !this.isEmptyOrNull(s.data.get('numerator')) && !this.isEmptyOrNull(s.data.get('denominator')) && !this.isEmptyOrNull(s.data.get('denominator_exc')) && !this.isEmptyOrNull(s.data.get('numerator_exc'))) {
-            measureList << s.eval((perfYear == '2018') ? SNIPPETS['2018_NONPROP_MEASURE_TPL'] : SNIPPETS['NONPROP_MEASURE_TPL'])
+            measureList << s.eval(SNIPPETS['NONPROP_MEASURE_TPL'])
           // Proportional Measure
           } else if (!this.isEmptyOrNull(s.data.get('performanceRate'))) {
-            measureList << s.eval((perfYear == '2018') ? SNIPPETS['2018_PROP_MEASURE_TPL'] : SNIPPETS['PROP_MEASURE_TPL'])
+            measureList << s.eval(SNIPPETS['PROP_MEASURE_TPL'])
           // Standard Single Measure
           } else {
-            measureList << s.eval((perfYear == '2018') ? SNIPPETS['2018_SINGLE_MEASURE'] : SNIPPETS['SINGLE_MEASURE'])
+            measureList << s.eval(SNIPPETS['SINGLE_MEASURE'])
           }
         }
       } else if (measureCategory == 'cost') {
@@ -243,15 +234,12 @@ class ScenarioReader {
   public String toMeasurementSets(List<Scenario> list) {
     def Set msetList = [];
     list.each { s ->
-      def measureCategory = s.data.get('category')
-      def perfYear = s.data.get('perf_year')
       def msetName = s.data.get('mset_id')
-      s.data.put('MEASUREMENTS', '${MEASUREMENTS_' + msetName + '}' )
-      if(perfYear == '2018' && measureCategory == 'quality') {
-        msetList << s.eval(SNIPPETS['2018_QUALITY_MSET_TEMPLATE'])
-      } else {
-        msetList << s.eval(SNIPPETS['MSET_TEMPLATE'])
+      if (this.isEmptyOrNull(s.data.get('provider_id'))) {
+        s.data.put('provider_id', '')
       }
+      s.data.put('MEASUREMENTS', '${MEASUREMENTS_' + msetName + '}' )
+      msetList << s.eval(SNIPPETS['MSET_TEMPLATE'])
     }
     return msetList.join(',');
   }
@@ -292,4 +280,7 @@ class ScenarioReader {
     this.currentScenarioList = this.it.next().value;
     copyScenarioProperties(this.propsStep, this.currentScenarioList)
   }
+
+// Make SoapUI Client Happy
+  public void close() { }
 }

--- a/src/com/eviware/soapui/TestCaseAuthorization.groovy
+++ b/src/com/eviware/soapui/TestCaseAuthorization.groovy
@@ -1,0 +1,62 @@
+package com.eviware.soapui;
+
+import org.apache.log4j.Logger
+import com.eviware.soapui.impl.wsdl.teststeps.*
+import com.eviware.soapui.support.types.StringToStringMap
+import com.eviware.soapui.impl.wsdl.testcase.WsdlTestCase
+import java.io.File
+import java.util.HashMap
+
+class TestCaseAuthorization {
+  private Map ENV
+  private Map TOKEN_MAP
+
+  private Map getEnvironmentValues(String projectPath) {
+    if(ENV == null) {
+      ENV = [:]
+      new File(projectPath + "/.env").eachLine { line ->
+        ENV.put(line.split("=")[0], line.split("=")[1])
+      }
+    }
+    return ENV
+  }
+
+  private Map getTokenMap(Logger log) {
+    if(TOKEN_MAP == null) {
+      TOKEN_MAP = [:]
+      def lineNo = 0
+      def line
+      new File(ENV.get("TOKEN_FILE_PATH")).withReader { reader ->
+        while ((line = reader.readLine()) != null) {
+          if(lineNo > 0) {
+            String[] values = line.split(",")
+            TOKEN_MAP.put(values[0].replaceAll("\"", "") + values[1].replaceAll("\"", ""), values[4])
+          }
+          lineNo++
+        }
+      }
+    }
+    return TOKEN_MAP
+  }
+
+	public TestCaseAuthorization(Logger log, WsdlTestCase testCase, String projectPath) {
+	  def ENV = getEnvironmentValues(projectPath)
+	  def TOKEN_MAP = getTokenMap(log)
+		for(testStep in testCase.getTestStepList()) {
+			if(testStep instanceof RestTestRequestStep) {
+			  def headers = new StringToStringMap()
+				testStep.getHttpRequest().setEndpoint(ENV.get("ENDPOINT"))
+				if(testStep.getHttpRequest().getEndpoint() ==~ /(?s).*dev.*/) {
+				  String key = "DEV" + ENV.get("USER_TYPE").toString()
+				  String devTokens = TOKEN_MAP.get(key).toString();
+          headers.put("Authorization","Bearer " + devTokens.replaceAll("\"", ""))
+				} else if(testStep.getHttpRequest().getEndpoint() ==~ /(?s).*imp.*/) {
+          String key = "IMP" + ENV.get("USER_TYPE").toString()
+          String impTokens = TOKEN_MAP.get(key).toString();
+          headers.put("Authorization","Bearer " + impTokens.replaceAll("\"", ""))
+        }
+				testStep.getHttpRequest().setRequestHeaders(headers)
+			}
+		}
+	}
+}


### PR DESCRIPTION
Added ability to switch endpoints dynamically from single configuration file ".env" found in qpp-scoring-engines/soapui folder. If end point requires JWT, token will automatically be applied to authorization header before soapui scripts are run.

---

### Summary

Added ability to switch endpoints dynamically from single configuration file ".env" found in qpp-scoring-engines/soapui folder. If end point requires JWT, token will automatically be applied to authorization header before soapui scripts are run.

### Test Plan

Things that have to pass. These are things that the reviewer(s) should be able to reproduce.

* [x] Verified Working locally
* [x] Unit tested
* [x] Integration tests pass
* [ ] Documented (technical doc and/or business requirements doc)

### Associated JIRA Tickets

* Tickets from https://jira.cms.gov/secure/RapidBoard.jspa?rapidView=1567&projectKey=QPPSF
* https://jira.cms.gov/browse/QPPSF-3449
* https://jira.cms.gov/browse/QPPSF-3632
* https://jira.cms.gov/browse/QPPSF-3608

### Reviewers

Comma separated list of people
@rockykitamura @NateTheGreatt @KyleApfel @bijujoseph