### PR TITLE
QPPSF-10016 - Added Benchmark Injection Ability at Individual Scenario Level

### DIFF
--- a/src/com/eviware/soapui/ScenarioReader.groovy
+++ b/src/com/eviware/soapui/ScenarioReader.groovy
@@ -1,5 +1,8 @@
 package com.eviware.soapui;
 
+import groovy.json.JsonSlurper;
+import groovy.json.JsonOutput;
+
 /* ScenarioReader
 ** :: Notes ::
 ** ScenarioReader is a class for processing .TSV files within the SoapUI framework and converting each row or group of rows into JSON to be saved as properties in the "prop" file of the corresponding scenario.
@@ -24,6 +27,7 @@ class ScenarioReader {
   static TEMPLATE_ENGINE = new groovy.text.SimpleTemplateEngine()
   static SNIPPETS = [:]
 
+  private String projectFolderPath;
   private File inputFile;
   private File outputFile;
   private BufferedReader reader;
@@ -60,7 +64,8 @@ class ScenarioReader {
 
   // ScenarioReader -- Class used to initialize all necessary files
   public ScenarioReader(String folder, String inputFileName, String outputFileName) {
-    this.cfgSnippets()
+    this.cfgSnippets();
+    this.projectFolderPath = folder;
     this.inputFile = new File(folder, inputFileName);
     this.outputFile = new File(folder, outputFileName);
     inputFile.eachLine {line, i ->
@@ -262,6 +267,22 @@ class ScenarioReader {
     }
     return msetList.join(',');
   }
+  
+  // toMeasurementSets -- Responsible for creating Props for multiple measurementSets defined by the `mset_id` column.
+  public String toBenchmark(List<Scenario> list) {
+    def benchmarkList = [];
+    def jsonSlurper = new JsonSlurper();
+    list.each { s ->
+      if (!this.isEmptyOrNull(s.data.get('benchmarkJson'))) {
+      	String osName = System.properties['os.name'];
+        boolean isWindows = osName.toLowerCase().contains('windows');
+      	String jsonFileName = isWindows ? s.data.get('benchmarkJson').replace("/", "\\") : s.data.get('benchmarkJson').replace("\\", "/");
+        File benchmarkJson = new File(this.projectFolderPath, s.data.get('benchmarkJson'));
+        benchmarkList.addAll(jsonSlurper.parse(benchmarkJson));
+      }
+    }
+    return JsonOutput.toJson(benchmarkList);
+  }
 
   // copyScenarioProperties -- Responsible for creating and updating all Props in the `prop` test step.
   public String copyScenarioProperties(def propsStep, List<Scenario> scenarios) {
@@ -271,6 +292,7 @@ class ScenarioReader {
         propsStep.setPropertyValue(k, v);
       }
       propsStep.setPropertyValue('MSETS', this.toMeasurementSets(scenarios))
+      propsStep.setPropertyValue('BENCHMARKS', this.toBenchmark(scenarios))
 
       def Set mSetsMeasurementProps = [];
       scenarios.each { s ->

--- a/src/com/eviware/soapui/ScenarioReader.groovy
+++ b/src/com/eviware/soapui/ScenarioReader.groovy
@@ -268,7 +268,7 @@ class ScenarioReader {
     return msetList.join(',');
   }
   
-  // toMeasurementSets -- Responsible for creating Props for multiple measurementSets defined by the `mset_id` column.
+  // toBenchmark -- Responsible for concatenating scenario level benchmark injection (i.e. from TSV level)
   public String toBenchmark(List<Scenario> list) {
     def benchmarkList = [];
     def jsonSlurper = new JsonSlurper();


### PR DESCRIPTION
Added Benchmark Injection Ability at Individual Scenario Level for SoapUI
---

### Summary

Updated SenarioReader to collect benchmark paths from scenario (line from TSV input files), parse the json and combine it into a single array of benchmarks for sending to the express server.

### Test Plan

Things that have to pass. These are things that the reviewer(s) should be able to reproduce.

* [x] Verified Working locally
* [x] Documented (technical doc and/or business requirements doc)

### Associated JIRA Tickets
_Tickets from https://jira.cms.gov/secure/RapidBoard.jspa?rapidView=1567&projectKey=QPPSF_

* https://jira.cms.gov/browse/QPPSF-10016

### Reviewers
* @KyleApfel
* @shadford
* @pkasarski
* @Jpec07
* @bkkwok
* @gerickson808
